### PR TITLE
Add build targets for linux/riscv64

### DIFF
--- a/Dockerfile.linux-riscv64
+++ b/Dockerfile.linux-riscv64
@@ -1,0 +1,12 @@
+ARG GO_VERSION
+FROM gotify/build:$GO_VERSION-linux-amd64
+RUN \
+  apt-get update && \
+  apt-get install -y gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
+
+ENV CGO_ENABLED=1
+ENV CC=riscv64-linux-gnu-gcc
+ENV CXX=riscv64-linux-gnu-g++
+ENV GOOS=linux
+ENV GOARCH=riscv64
+

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,11 @@ build-linux-arm64:
 push-linux-arm64:
 	docker push ${PROJECT}:${GO_VERSION}-linux-arm64
 
-build: build-linux-amd64 build-linux-arm-7 build-linux-arm64 build-linux-386 build-windows-amd64 build-windows-386
-push:  push-linux-amd64  push-linux-arm-7  push-linux-arm64  push-linux-386  push-windows-amd64  push-windows-386
+build-linux-riscv64:
+	docker build --build-arg GO_VERSION=${GO_VERSION} -t ${PROJECT}:${GO_VERSION}-linux-riscv64 -f Dockerfile.linux-riscv64 .
+
+push-linux-riscv64:
+	docker push ${PROJECT}:${GO_VERSION}-linux-riscv64
+
+build: build-linux-amd64 build-linux-arm-7 build-linux-arm64 build-linux-riscv64 build-linux-386 build-windows-amd64 build-windows-386
+push:  push-linux-amd64  push-linux-arm-7  push-linux-arm64 push-linux-riscv64 push-linux-386  push-windows-amd64  push-windows-386


### PR DESCRIPTION
Add build support for the RISC-V architecture to gotify.

RISC-V is an open standard instruction set architecture, which is under rapid development. Distributions including AOSP, Arch Linux, Debian, Gentoo Linux, Fedora, OpenEuler, etc are also actively doing porting work for this architecture.