### PR TITLE
Fix renovate CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,5 +52,8 @@ jobs:
             exit 1
           fi
 
+          git config user.name "gotifyci"
+          git config user.email "gotifyci@gotify.net"
+          
           git tag "v${GO_VERSION}" -m "Bump to Go $GO_VERSION"
           git push origin --tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
           git config user.name "gotifyci"
-          git config user.email "gotifyci@gotify.net"
+          git config user.email "gotify@protonmail.com"
           
           git tag "v${GO_VERSION}" -m "Bump to Go $GO_VERSION"
           git push origin --tags

--- a/renovate.json
+++ b/renovate.json
@@ -20,11 +20,11 @@
       ],
       "depTypeTemplate": "language",
       "matchStrings": [
-        "^(?<currentValue>.+)\\n"
+        "^(?<currentValue>[0-9.]+)"
       ],
       "extractVersionTemplate": "^(?<version>.+)-bookworm$",
       "depNameTemplate": "docker.io/library/golang",
-      "autoReplaceStringTemplate": "{{{newValue}}}\n",
+      "autoReplaceStringTemplate": "{{{newValue}}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       ],
       "extractVersionTemplate": "^(?<version>.+)-bookworm$",
       "depNameTemplate": "docker.io/library/golang",
-      "autoReplaceStringTemplate": "{{{newValue}}}",
+      "autoReplaceStringTemplate": "{{{newValue}}}\n",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }


### PR DESCRIPTION
Forgot GitHub does not set committer information automatically...

I can't find out why renovate is not able to create the branch and I need to manually push the branch and it seems to go through (permissions?). I only see this in the log: It all looks correct, the labels are created, everything looks normal in the onboarding PR ... I only found this newline maybe issue that may or may not be related.

Broken build: https://developer.mend.io/github/gotify/build/-/job/b48ea4a9-b6e4-466e-8f94-56b039a1a4e8

```
Error updating branch: update failure
```
