### PR TITLE
fetch all tags on checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Sanity check
       run: |


### PR DESCRIPTION
The current github actions checkout is shallow causing missing tags on the detection part and will become an error later. 


See https://github.com/gotify/build/pull/8#discussion_r1825693017

Signed-off-by: eternal-flame-AD <yume@yumechi.jp>